### PR TITLE
fix: pass network seed on to sandbox

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -301,6 +301,7 @@ app.whenReady().then(async () => {
     CLI_OPTS.bootstrapUrl ? CLI_OPTS.bootstrapUrl : bootstrapUrl,
     CLI_OPTS.singalingUrl ? CLI_OPTS.singalingUrl : signalingUrl,
     CLI_OPTS.appId,
+    CLI_OPTS.networkSeed,
   );
 
   const lairUrls: string[] = [];


### PR DESCRIPTION
The network seed passed via command line argument was not actually forwarded to the hc sandbox generate command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for specifying a network seed when creating sandboxes, allowing for more controlled and repeatable sandbox environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->