### PR TITLE
chore: release 0.500.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 ### Removed
 
+## 2025-07-31: v0.500.3
+### Fixed
+- The `--network-seed` argument to hc sandbox was not actually passed on to hc sandbox. Fixed with [#33](https://github.com/holochain/hc-spin/pull/33)
+
 ## 2025-07-09: v0.500.2
 ### Fixed
 - Fixes issue [#31](https://github.com/holochain/hc-spin/issues/30) that made initial zome calls fail in cases where the UI loaded faster than the zome call signing logic was ready (PR [#31](https://github.com/holochain/hc-spin/pull/31))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@holochain/hc-spin",
-  "version": "0.500.2",
-  "holochainVersion": "0.5.3",
+  "version": "0.500.3",
+  "holochainVersion": "0.5.4",
   "description": "CLI to run Holochain apps during development.",
   "author": "matthme",
   "homepage": "https://developer.holochain.org",
@@ -35,7 +35,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.0",
     "@electron-toolkit/utils": "^3.0.0",
-    "@holochain/client": "^0.19.1",
+    "@holochain/client": "^0.19.2",
     "@holochain/hc-spin-rust-utils": "^0.500.0",
     "@msgpack/msgpack": "^2.8.0",
     "bufferutil": "4.0.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -468,10 +468,10 @@
   resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.1.tgz#de633db3ec2ef6a3c89e2f19038063e8a122e2c2"
   integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
 
-"@holochain/client@^0.19.1":
-  version "0.19.1"
-  resolved "https://registry.yarnpkg.com/@holochain/client/-/client-0.19.1.tgz#b905c4b144f8ce7830e8d40f8a623c9eec6c6c0b"
-  integrity sha512-/TLkP2rMesNU/e71UFvOFPJ6Hi1bgePLTMM8Rfk8WEnIYMquBG4h4tklZN1VdtivctNRn6K6QV2ID05JjdOgyQ==
+"@holochain/client@^0.19.2":
+  version "0.19.2"
+  resolved "https://registry.yarnpkg.com/@holochain/client/-/client-0.19.2.tgz#822bd7c17859606ed29ce5578d446e3d0ca9bfbc"
+  integrity sha512-73l/YziQwnNXsO9bxuzstc6eQh/T7ljY2d5CEBJtoRXsvJwl8T+54et2XM+BOdrcUG3lj+hZeIdcD3kbnP3asA==
   dependencies:
     "@bitgo/blake2b" "^3.2.4"
     "@msgpack/msgpack" "^3.1.1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where the `--network-seed` argument was not correctly passed to the sandbox process in the `hc sandbox` command.

* **Chores**
  * Updated package version to 0.500.3.
  * Upgraded Holochain dependency to version 0.5.4.
  * Updated `@holochain/client` dependency to version 0.19.2.
  * Added a new changelog entry for this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->