### PR TITLE
chore: release 0.600.0-dev.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 ### Fixed
 ### Changed
-- Bumped to holochain 0.6.0-dev.28
 ### Removed
+
+## 2025-10-13: v0.600.0-dev.0
+
+### Changed
+- Bumped to holochain 0.6.0-dev.28
 
 ## 2025-07-31: v0.500.3
 ### Fixed


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog with a new dated entry: 2025-10-13 (v0.600.0-dev.0) noting the bump to Holochain 0.6.0-dev.28.
  * Removed the prior Unreleased placeholder for this change to reflect a finalized release entry.
  * Preserved existing historical entries and refined the structure for clearer release history.
  * No functional changes to features or behavior; this update improves transparency and traceability of version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->