### PR TITLE
ability to spin up n zero-arc nodes

### DIFF
--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -23,6 +23,7 @@ export async function createHappWindow(
   appPort: number,
   appAuthToken: AppAuthenticationToken,
   appDataRootDir: string,
+  agentType?: 'full-arc' | 'zero-arc',
 ): Promise<BrowserWindow> {
   // TODO create mapping between installed-app-id's and window ids
   if (!appPort) throw new Error('App port not defined.');
@@ -79,12 +80,14 @@ electron.contextBridge.exposeInMainWorld("__HC_LAUNCHER_ENV__", {
     }
   }
 
+  const titlePrefix = agentType === 'zero-arc' ? 'Zero-Arc Agent' : 'Agent';
+  
   return new BrowserWindow({
     width: 1200,
     height: 800,
     show: false,
     icon,
-    title: `Agent ${agentNum} - ${appId}`,
+    title: `${titlePrefix} ${agentNum} - ${appId}`,
     webPreferences: {
       preload: preloadPath,
       partition,


### PR DESCRIPTION
Dependancy: https://github.com/holochain/holochain/pull/5403

Resolves #40 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `-z, --num-zero-arc-agents` CLI option to spawn zero-arc agents alongside standard full-arc agents
  * Zero-arc and full-arc agents are now independently configured and visually distinguished with unique window labels
  * Agent numbering automatically adjusts when both agent types are active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->