### PR TITLE
docs: added documentation about how to update to a new holochain version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ CLI to run Holochain apps in development mode.
 
 ## Installation
 
-To install the latest version compatible with **holochain 0.4.x**:
+To install the latest version compatible with **holochain 0.6.x**:
 
-⚠️ Requires `@holochain/client 0.18.0` or newer ⚠️
+⚠️ Requires `@holochain/client 0.20.0` or newer ⚠️
 
 ```sh
-npm install --save-dev @holochain/hc-spin@">=0.400.0 <0.500.0"
+npm install --save-dev @holochain/hc-spin@">=0.600.0 <0.700.0"
 ```
 
 To install the latest version compatible with **holochain 0.5.x**:
@@ -20,12 +20,12 @@ To install the latest version compatible with **holochain 0.5.x**:
 npm install --save-dev @holochain/hc-spin@">=0.500.0 <0.600.0"
 ```
 
-To install the latest version compatible with **holochain 0.6.x**:
+To install the latest version compatible with **holochain 0.4.x**:
 
-⚠️ Requires `@holochain/client 0.20.0` or newer ⚠️
+⚠️ Requires `@holochain/client 0.18.0` or newer ⚠️
 
 ```sh
-npm install --save-dev @holochain/hc-spin@">=0.600.0 <0.700.0"
+npm install --save-dev @holochain/hc-spin@">=0.400.0 <0.500.0"
 ```
 
 ## Usage (holochain 0.6)

--- a/docs/DEVSETUP.md
+++ b/docs/DEVSETUP.md
@@ -25,3 +25,14 @@ yarn build
 ```bash
 yarn start <path to .webhapp file>
 ```
+
+## Upgrade hc-spin to a new holochain version
+
+1. Upgrade the upstream `@holochain/hc-spin-rust-utils` package [in this repo](https://github.com/holochain/hc-spin-rust-utils), following the instructions in its README.
+2. Once the new `@holochain/hc-spin-rust-utils` package has been upgraded and released, update it accordingly in the `package.json` file.
+3. Update `@holochain/client` in the `package.json` file to the appropriate version.
+4. Check whether any code changes are necessary after updating the packages. Once the code has been adapted, test it with `yarn start <path to .webhapp file>`.
+5. If testing succeeds, update the `version` field in `package.json`.
+6. Make any changes as necessary to the README. The README is what is shown on npmjs.org as the package description so it should be up to date.
+7. Build the hc-spin binary with `yarn build`.
+8. And finally publish it with `npm publish`.


### PR DESCRIPTION
Adds documentation about repo maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions with holochain version compatibility information for 0.4.x, 0.5.x, and 0.6.x releases, including corresponding client and hc-spin version requirements.
  * Added guide for upgrading hc-spin to a new holochain version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->