### PR TITLE
chore: add a release automation workflows

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -1,0 +1,19 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Exact version to release (e.g. 1.2.3). Leave empty to infer from commits."
+        required: false
+        type: string
+
+jobs:
+  prepare:
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.9.0
+    with:
+      cliff_config_url: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
+      force_version: ${{ inputs.version }}
+      package_manager: yarn
+    secrets:
+      GH_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,13 @@
+name: Publish Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  publish:
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.9.0
+    with:
+      package_manager: yarn
+    secrets:
+      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This uses the new Node.js common workflows from the Holochain actions repo, added in holochain/actions#10. These can't really be tested until they are merged to main.

Closes #62.