### PR TITLE
ci: fix release workflow permissions

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   prepare:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.9.0
     with:
       cliff_config_url: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,10 +10,7 @@ on:
 
 jobs:
   prepare:
-    permissions:
-      contents: write
-      pull-requests: write
-    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.9.0
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.10.0
     with:
       cliff_config_url: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
       force_version: ${{ inputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.9.0
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.10.0
     with:
       package_manager: yarn
     secrets:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    permissions:
+      contents: write
+      id-token: write
     uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.9.0
     with:
       package_manager: yarn


### PR DESCRIPTION
Update the workflow versions which have removed the unnecessary prepare permissions and then add the missing permissions for the publish workflow.