### PR TITLE
Boyscouting nix prettier ci

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Exact version to release (e.g. 1.2.3). Leave empty to infer from commits."
+        description: 'Exact version to release (e.g. 1.2.3). Leave empty to infer from commits.'
         required: false
         type: string
 
@@ -12,7 +12,7 @@ jobs:
   prepare:
     uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.10.0
     with:
-      cliff_config_url: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
+      cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
       force_version: ${{ inputs.version }}
       package_manager: yarn
     secrets:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,9 @@ jobs:
       - name: Install dependencies
         run: yarn
 
+      - name: Format
+        run: yarn format:check
+
       - name: Lint
         run: yarn lint:check
 


### PR DESCRIPTION
Publishing of 0.700.0-dev.2 failed due to the incorrect formatting of the CI file (see [this run](https://github.com/holochain/hc-spin/actions/runs/27124720580/job/80050229003)). This PR fixes that formatting issue and also updates the test CI workflow that runs on PRs to check the formatting to hopefully stop this happening again.