### PR TITLE
ci: update action versions

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prepare:
-    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.10.0
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.11.0
     with:
       cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
       force_version: ${{ inputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.10.0
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.11.0
     with:
       package_manager: yarn
     secrets:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       # Checks out a copy of your repository on the ubuntu-latest machine
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
Publishing was failing due to how the release notes were generated and packaged (see [here](https://github.com/holochain/hc-spin/actions/runs/27128679995/job/80063807195)).

The issue is [hopefully] fixed in v1.11.0.

Also updated the checkout action to the latest version that we use everywhere else whilst I was doing this.

Hopefully after this PR the release will actually publish :crossed_fingers:.