### PR TITLE
ci: update release automation actions and remove NPM_TOKEN secret

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prepare:
-    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.11.0
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.12.0
     with:
       cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
       force_version: ${{ inputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,8 +9,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.11.0
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.12.0
     with:
       package_manager: yarn
-    secrets:
-      NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The latest version of the release automation workflow uses trusted publishers to publish packages instead of a token.

Fourth time's a charm... hopefully this will allow `npm publish` to finish successfully.