### PR TITLE
ci: update release workflows to fix publishing with them

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   prepare:
-    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.12.0
+    uses: holochain/actions/.github/workflows/nodejs-prepare-release.yml@v1.13.0
     with:
       cliff_config_url: 'https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml'
       force_version: ${{ inputs.version }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,6 +9,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.12.0
+    uses: holochain/actions/.github/workflows/nodejs-publish-release.yml@v1.13.0
     with:
       package_manager: yarn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,50 +4,6 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[[0.700.0-dev.5](https://github.com/holochain/hc-spin/compare/v0.700.0-dev.4...v0.700.0-dev.5)\] - 2026-06-09
-
-### CI
-
-- Update release automation actions and remove NPM_TOKEN secret by @cdunster in [#72](https://github.com/holochain/hc-spin/pull/72)
-  - The latest version of the release automation workflow uses trusted publishers to publish packages instead of a token.
-
-## \[[0.700.0-dev.4](https://github.com/holochain/hc-spin/compare/v0.700.0-dev.3...v0.700.0-dev.4)\] - 2026-06-08
-
-### CI
-
-- Update checkout action in test workflow by @cdunster in [#70](https://github.com/holochain/hc-spin/pull/70)
-- Update release automation actions to fix publish issue by @cdunster
-  - Publishing was failing due to how the release notes were generated and packaged. v1.11.0 fixes that issue.
-
-## \[[0.700.0-dev.3](https://github.com/holochain/hc-spin/compare/v0.700.0-dev.2...v0.700.0-dev.3)\] - 2026-06-08
-
-### Miscellaneous Tasks
-
-- Add direnv support to use the Nix devShell by @cdunster
-
-### CI
-
-- Fix string formatting in release-prepare workflow by @cdunster in [#68](https://github.com/holochain/hc-spin/pull/68)
-- Add formatting check step to PR tests by @cdunster
-
-## \[[0.700.0-dev.2](https://github.com/holochain/hc-spin/compare/v0.700.0-dev.1...v0.700.0-dev.2)\] - 2026-06-04
-
-### Miscellaneous Tasks
-
-- Add prepublish script to try to ensure an up-to-date publish by @ThetaSinner
-
-### CI
-
-- Update the Node.js release workflows by @cdunster in [#64](https://github.com/holochain/hc-spin/pull/64)
-- Add missing write permissions in release workflows by @cdunster
-- Add workflow to publish the prepared release by @cdunster in [#63](https://github.com/holochain/hc-spin/pull/63)
-- Add workflow to prepare a release by @cdunster
-
-### First-time Contributors
-
-- @cdunster made their first contribution in [#64](https://github.com/holochain/hc-spin/pull/64)
-- @ThetaSinner made their first contribution
-
 ## 2026-02-13: v0.700.0-dev.1
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@holochain/hc-spin",
-  "version": "0.700.0-dev.5",
+  "version": "0.700.0-dev.8",
   "holochainVersion": "0.7.0-dev.7",
   "description": "CLI to run Holochain apps during development.",
   "author": "matthme",


### PR DESCRIPTION
This was tested using the feature development branch in https://github.com/holochain/actions before a new release was created in that repo, see [this CI job](https://github.com/holochain/hc-spin/actions/runs/27209734639/job/80335171989) as proof that the changes worked. That branch was merged and the new `v1.13.0` release was created. This PR updates to that version.

The package was bumped to version `0.700.0-dev.8` as that version was published as a test to NPM and then unpublished to stop it being used. But even unpublished versions can't be reused so we need to release `0.700.0-dev.9` next. The entries were removed from the changelog though because they were all test releases and `0.700.0-dev.9` will contain all the changes since `0.700.0-dev.1`.